### PR TITLE
chore(security): add reusable security gate

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,3 +19,4 @@ jobs:
     with:
       paths: "."
       fail-on-findings: true
+    secrets: inherit


### PR DESCRIPTION
Adds a 5-line caller that delegates scanning to lubysoftware/security-workflow.

Coverage on this repo:
- pull_request: every PR (any base branch) is gated.
- push: direct pushes to main/master/develop/staging/prod re-run the gate.

Centralized rules; updates to lubysoftware/security-workflow propagate to all repos automatically.